### PR TITLE
More test coverage, populate associations only if config setting is true

### DIFF
--- a/actions/find.js
+++ b/actions/find.js
@@ -34,7 +34,6 @@ module.exports = function findRecords (req, res) {
   if ( actionUtil.parsePk(req) ) {
     return require('./findOne')(req,res);
   }
-
   // Lookup for records that match the specified criteria
   Model.findAll({
     where: actionUtil.parseCriteria(req),

--- a/actions/find.js
+++ b/actions/find.js
@@ -40,7 +40,7 @@ module.exports = function findRecords (req, res) {
     limit: actionUtil.parseLimit(req),
     offset: actionUtil.parseSkip(req),
     order: actionUtil.parseSort(req),
-    include: [{ all: sails.config.blueprints.populate }]
+    include: sails.config.blueprints.populate ? [{ all: true }] : []
   }).then(function(matchingRecords) {
     // Only `.watch()` for new instances of the model if
     // `autoWatch` is enabled.

--- a/actions/find.js
+++ b/actions/find.js
@@ -41,7 +41,7 @@ module.exports = function findRecords (req, res) {
     limit: actionUtil.parseLimit(req),
     offset: actionUtil.parseSkip(req),
     order: actionUtil.parseSort(req),
-    include: [{ all: true }]
+    include: [{ all: sails.config.blueprints.populate }]
   }).then(function(matchingRecords) {
     // Only `.watch()` for new instances of the model if
     // `autoWatch` is enabled.

--- a/actions/findOne.js
+++ b/actions/findOne.js
@@ -21,7 +21,6 @@ var actionUtil = require('../actionUtil');
 module.exports = function findOneRecord (req, res) {
   var Model = actionUtil.parseModel(req);
   var pk = actionUtil.requirePk(req);
-
   Model.findById(pk, { include: [{ all: sails.config.blueprints.populate }]}).then(function(matchingRecord) {
     if(!matchingRecord) return res.notFound('No record found with the specified `id`.');
 

--- a/actions/findOne.js
+++ b/actions/findOne.js
@@ -21,7 +21,8 @@ var actionUtil = require('../actionUtil');
 module.exports = function findOneRecord (req, res) {
   var Model = actionUtil.parseModel(req);
   var pk = actionUtil.requirePk(req);
-  Model.findById(pk, { include: [{ all: sails.config.blueprints.populate }]}).then(function(matchingRecord) {
+  Model.findById(pk, {include: sails.config.blueprints.populate ? [{ all: true }] : []
+  }).then(function(matchingRecord) {
     if(!matchingRecord) return res.notFound('No record found with the specified `id`.');
 
     if (sails.hooks.pubsub && req.isSocket) {

--- a/actions/findOne.js
+++ b/actions/findOne.js
@@ -22,7 +22,7 @@ module.exports = function findOneRecord (req, res) {
   var Model = actionUtil.parseModel(req);
   var pk = actionUtil.requirePk(req);
 
-  Model.findById(pk, { include: [{ all: true }]}).then(function(matchingRecord) {
+  Model.findById(pk, { include: [{ all: sails.config.blueprints.populate }]}).then(function(matchingRecord) {
     if(!matchingRecord) return res.notFound('No record found with the specified `id`.');
 
     if (sails.hooks.pubsub && req.isSocket) {

--- a/test/fixtures/sampleapp/api/models/image.js
+++ b/test/fixtures/sampleapp/api/models/image.js
@@ -17,7 +17,8 @@ module.exports = {
             as: 'owner',
             foreignKey: {
                 name: 'userId',
-                as: 'owner'
+                as: 'owner',
+                allowNull: false
             }
         });
     },

--- a/test/unit/controllers/Blueprint.test.js
+++ b/test/unit/controllers/Blueprint.test.js
@@ -54,6 +54,12 @@ describe('Sequelize Blueprint User', function(){
         .expect(200, done);
     });
 
+    it('Get single user', function(done){
+        request(sails.hooks.http.app)
+        .get('/user/1')
+        .expect(200, done);
+    });
+
     it('Create an image without an owner', function(done){
         request(sails.hooks.http.app)
         .post('/image')


### PR DESCRIPTION
I was having a test fail, so I needed to add notNull constraint to image.user association.  Also having include: [{all: true}] can lead to performance issues if there are many associations, so it now just does a simple check of the config settings.  Ideally it should mimic the behaviour of sails' ActionUtil.populateEach', but this is a start.
