### PR TITLE
Access sails in req object

### DIFF
--- a/actions/find.js
+++ b/actions/find.js
@@ -40,7 +40,7 @@ module.exports = function findRecords (req, res) {
     limit: actionUtil.parseLimit(req),
     offset: actionUtil.parseSkip(req),
     order: actionUtil.parseSort(req),
-    include: sails.config.blueprints.populate ? [{ all: true }] : []
+    include: req._sails.config.blueprints.populate ? [{ all: true }] : []
   }).then(function(matchingRecords) {
     // Only `.watch()` for new instances of the model if
     // `autoWatch` is enabled.

--- a/actions/findOne.js
+++ b/actions/findOne.js
@@ -21,7 +21,7 @@ var actionUtil = require('../actionUtil');
 module.exports = function findOneRecord (req, res) {
   var Model = actionUtil.parseModel(req);
   var pk = actionUtil.requirePk(req);
-  Model.findById(pk, {include: sails.config.blueprints.populate ? [{ all: true }] : []
+  Model.findById(pk, {include: req._sails.config.blueprints.populate ? [{ all: true }] : []
   }).then(function(matchingRecord) {
     if(!matchingRecord) return res.notFound('No record found with the specified `id`.');
 


### PR DESCRIPTION
We do not know if sails is globally available and therefore we should use the reference to sails from the `req` object.
